### PR TITLE
Release v2026.06.17.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 dependencies = ["sympy", "numpy", "scipy", "xarray", "numba", "parcels @ git+https://github.com/parcels-code/parcels.git@17241585384f9cbb04a796cb3581cb49559df9df"]
 name = "mechanical_drifters"
 requires-python = ">= 3.11"
-version = "0.1.0"
+version = "2026.06.17.1"
 description = "Lagrangian mechanics models for ocean drifters"
 license = "MIT"
 authors = [


### PR DESCRIPTION
Release **v2026.06.17.1**.

The spar-buoy model and its examples/tests are already on `main` (merged via #21/#22). This PR contains only the version bump for the release.

## Change
- `pyproject.toml`: version `0.1.0` → `2026.06.17.1` (synced to the calendar release tag).

## After squash-merge
1. `git checkout main && git pull`
2. `git tag v2026.06.17.1 && git push origin v2026.06.17.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)